### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/apps/fastapi_app.py
+++ b/apps/fastapi_app.py
@@ -36,6 +36,9 @@ async def upload_return_large_file(file: UploadFile = File(...)):
 
 @app.get("/cmdi")
 def cmdi(user_input: str):
+    ALLOWLIST = ["hello", "world", "test"]
+    if user_input not in ALLOWLIST:
+        return {"error": "Invalid command"}
     cmd = "echo " + user_input + " this should be echoed"
     print("Started app view")
     for i in range(10):


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_1/security/code-scanning/1](https://github.com/digiALERT1/Python_1/security/code-scanning/1)

To fix the problem, we should avoid directly using user input to construct shell commands. Instead, we can use a predefined allowlist of acceptable commands or sanitize the input to ensure it does not contain any malicious content. In this case, we will use a predefined allowlist to ensure only safe commands are executed.

We will modify the `cmdi` function to check the user input against a predefined allowlist of safe commands. If the input is not in the allowlist, we will return an error message instead of executing the command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
