### PR TITLE
Fix code scanning alert no. 6: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/aiohttp/vulnerable_routes.py
+++ b/src/vulnpy/aiohttp/vulnerable_routes.py
@@ -1,7 +1,7 @@
 from aiohttp import web
 from vulnpy.common import get_template
 from vulnpy.trigger import TRIGGER_MAP, get_trigger
-
+import html
 
 def _get_user_input(request):
     return request.rel_url.query.get("user_input", "")
@@ -26,7 +26,7 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            template += "<p>XSS: " + html.escape(user_input) + "</p>"
 
         return web.Response(text=template, content_type="text/html")
 


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_1/security/code-scanning/6](https://github.com/digiALERT1/Python_1/security/code-scanning/6)

To fix the reflected server-side cross-site scripting vulnerability, we need to escape the user input before including it in the HTML response. In Python, we can use the `html.escape()` function from the `html` module to escape special characters in the user input, preventing the execution of malicious scripts.

The best way to fix the problem without changing existing functionality is to import the `html` module and use the `html.escape()` function to sanitize the `user_input` before appending it to the `template` variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
