### PR TITLE
Fix code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/django/vulnerable.py
+++ b/src/vulnpy/django/vulnerable.py
@@ -1,4 +1,5 @@
 from django.http import HttpResponse
+from django.utils.html import escape
 
 try:
     from django.conf.urls import url as compat_url
@@ -33,7 +34,7 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            template += "<p>XSS: " + escape(user_input) + "</p>"
 
         return HttpResponse(template)
 


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_1/security/code-scanning/5](https://github.com/digiALERT1/Python_1/security/code-scanning/5)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user input included in the HTML response is properly escaped. In Django, we can use the `django.utils.html.escape` function to escape special characters in the user input, preventing the execution of any injected scripts.

The best way to fix the problem without changing existing functionality is to import the `escape` function from `django.utils.html` and use it to escape the `user_input` before including it in the `template` string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
