### PR TITLE
Fix code scanning alert no. 4: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/django/vulnerable_asgi.py
+++ b/src/vulnpy/django/vulnerable_asgi.py
@@ -52,7 +52,8 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            import html
+            template += "<p>XSS: " + html.escape(user_input) + "</p>"
 
         return HttpResponse(template)
 


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Python_1/security/code-scanning/4](https://github.com/digiALERT1/Python_1/security/code-scanning/4)

To fix the reflected XSS vulnerability, we need to ensure that any user input included in the HTML response is properly escaped. This can be achieved by using the `html.escape()` function from the standard library, which will convert special characters to their corresponding HTML-safe sequences.

The best way to fix the problem without changing existing functionality is to escape the `user_input` before including it in the `template` string. This change should be made in the `get_trigger_view` function where the `user_input` is appended to the `template`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
